### PR TITLE
chore(bors): do not delete merged branches

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,3 @@
 status = [
   "continuous-integration/travis-ci/push",
 ]
-
-delete_merged_branches = true


### PR DESCRIPTION
Removes the delete merged branch directive to prevent conflicts with dependabot.